### PR TITLE
Only the first method parameter is checked

### DIFF
--- a/coding_standards/LiipDrupalPractice/Sniffs/NamingConventions/CamelCaseMethodParameterSniff.php
+++ b/coding_standards/LiipDrupalPractice/Sniffs/NamingConventions/CamelCaseMethodParameterSniff.php
@@ -50,7 +50,7 @@ class CamelCaseMethodParameterSniff extends AbstractScopeSniff
           $methodName = ltrim($methodParam['name'],"$");
 
             if (preg_match('/^[a-z]/', $methodName) === 1 && strpos($methodName, '_') === false) {
-                return;
+                continue;
             }
 
             $warning = 'Method parameter should user lowerCamel naming without underscores: %s';


### PR DESCRIPTION
When checking whether method parameters are camelcased, the `CamelCaseMethodParameterSniff` currently will stop processing as soon as it finds a valid parameter. It should check the remaining parameters as well.